### PR TITLE
fix: switch to Alpine 3.23 and guard libusb_init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,12 @@
-FROM gcc:15.2@sha256:9cc747b141fb69baaff237936f742f579fe6439e5b3b533b1c40d82374d220a0 AS builder
-ENV DEBIAN_FRONTEND=noninteractive
-ENV TERM=xterm
+FROM alpine:3.23 AS builder
 
-# Install base environment
-RUN apt-get update \
-  && apt-get install -qqy --no-install-recommends apt-utils ca-certificates \
-  apt-transport-https \
-  libusb-1.0-0-dev libpaho-mqtt-dev libssl-dev
+RUN apk add --no-cache gcc musl-dev libusb-dev paho-mqtt-c-dev openssl-dev
 
 COPY airsensor.c airsensor.h /
 RUN gcc -o airsensor airsensor.c -lusb-1.0 -lpaho-mqtt3cs -lpthread -lssl -lcrypto
 
-FROM debian:trixie-slim
-RUN apt-get update \
-  && apt-get install -qqy --no-install-recommends \
-  libusb-1.0-0 libpaho-mqtt1.3 ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
+FROM alpine:3.23
+RUN apk add --no-cache libusb paho-mqtt-c ca-certificates-bundle
 COPY --from=builder /airsensor /airsensor
 # Runs as root: libusb 1.0 requires root for USB device enumeration
 ENTRYPOINT ["/airsensor", "-v"]

--- a/airsensor.c
+++ b/airsensor.c
@@ -251,7 +251,11 @@ static libusb_device_handle* init_usb(int vendor, int product, int usb_timeout) 
     int ret;
 
     LOG_DEBUG("Init USB");
-    libusb_init(NULL);
+    ret = libusb_init(NULL);
+    if (ret < 0) {
+        LOG_ERROR("libusb_init failed: %s", libusb_error_name(ret));
+        return NULL;
+    }
 
     libusb_device_handle *handle = NULL;
     int counter = 0;
@@ -408,6 +412,11 @@ int main(int argc, char *argv[])
     int expire_after = cfg.poll_interval * 3;
 
     devh = init_usb(0x03eb, 0x2013, cfg.usb_timeout);
+    if (!devh) {
+        MQTTClient_disconnect(client, 10000);
+        MQTTClient_destroy(&client);
+        exit(1);
+    }
 
     device_flags_t dev_flags;
     int flags_valid;

--- a/airsensor.h
+++ b/airsensor.h
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define APP_VERSION "1.0.0"
+#define APP_VERSION "1.0.1"
 
 /* --------------------------------------------------------------------------
  * Device data types


### PR DESCRIPTION
## Summary
- **Docker image size reduced from 125MB to 14MB** (-89%) by replacing `debian:trixie-slim` with `alpine:3.23`
- **Reduced attack surface**: eliminates libudev, libz, libzstd, libcap dependencies
- **Guard against SIGSEGV**: checks `libusb_init()` return code — exits cleanly with error message instead of crashing when USB subsystem is unavailable
- Bumps `APP_VERSION` to 1.0.1

## Test plan
- [x] `make test` — 193/193 unit tests pass
- [x] E2E: mosquitto broker + airsensor container with `--privileged` and real USB sensor — all MQTT messages (discovery, availability, VOC data, diagnostics) published correctly
- [x] Without `--privileged`: clean `libusb_init failed: LIBUSB_ERROR_OTHER` + exit 1 (no SIGSEGV)